### PR TITLE
feat: convert to Claude Code plugin structure

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,0 +1,19 @@
+{
+  "name": "obsidian",
+  "version": "1.0.0",
+  "description": "Create and edit Obsidian vault files including Markdown, Bases, and Canvas. Use when working with .md, .base, or .canvas files in an Obsidian vault.",
+  "author": {
+    "name": "Obsidian",
+    "url": "https://obsidian.md"
+  },
+  "repository": "https://github.com/obsidianmd/obsidian-skills",
+  "license": "MIT",
+  "keywords": [
+    "obsidian",
+    "markdown",
+    "bases",
+    "canvas",
+    "pkm",
+    "notes"
+  ]
+}

--- a/README.md
+++ b/README.md
@@ -1,13 +1,66 @@
-Claude Skills for use with Obsidian.
+# Obsidian Skills for Claude Code
+
+Claude Code skills for creating and editing Obsidian vault files.
+
+## Skills Included
+
+| Skill | Description | File Types |
+|-------|-------------|------------|
+| [obsidian-markdown](./skills/obsidian-markdown/) | Obsidian Flavored Markdown with wikilinks, embeds, callouts, and properties | `.md` |
+| [obsidian-bases](./skills/obsidian-bases/) | Database-like views with filters, formulas, and summaries | `.base` |
+| [json-canvas](./skills/json-canvas/) | Infinite canvas with nodes, edges, and groups | `.canvas` |
 
 ## Installation
 
-Add the contents of this repo to a `/.claude` folder in the root of your Obsidian vault (or whichever folder you're using with Claude Code). See more in the [official Claude Skills documentation](https://platform.claude.com/docs/en/agents-and-tools/agent-skills/overview).
+### As a Claude Code Plugin (Recommended)
 
-## Skills
+Install directly from the Obsidian marketplace:
 
-### Create and edit Obsidian-compatible plain text files
+```bash
+claude plugin add obsidian@kepano
+claude plugin install obsidian@kepano
+```
 
-- [Obsidian Flavored Markdown](https://help.obsidian.md/obsidian-flavored-markdown) `.md`
-- [Obsidian Bases](https://help.obsidian.md/bases/syntax) `.base`
-- [JSON Canvas](https://jsoncanvas.org/) `.canvas`
+### Manual Installation
+
+Clone or copy this repository into your project's `.claude/plugins/` directory:
+
+```bash
+# Option 1: Clone into plugins directory
+mkdir -p .claude/plugins
+git clone https://github.com/obsidianmd/obsidian-skills.git .claude/plugins/obsidian
+
+# Option 2: Add as git submodule
+git submodule add https://github.com/obsidianmd/obsidian-skills.git .claude/plugins/obsidian
+```
+
+### Legacy Installation (Skills Only)
+
+Copy the `skills/` directory contents into your `.claude/skills/` folder:
+
+```bash
+cp -r skills/* .claude/skills/
+```
+
+## Usage
+
+Once installed, Claude Code will automatically use these skills when working with Obsidian files. The skills provide:
+
+- **Syntax guidance** for Obsidian-specific features (wikilinks, callouts, embeds)
+- **Schema documentation** for `.base` and `.canvas` file formats
+- **Best practices** for structuring notes and databases
+- **Complete function references** for Bases formulas
+
+## Documentation
+
+- [Obsidian Flavored Markdown](https://help.obsidian.md/obsidian-flavored-markdown)
+- [Obsidian Bases](https://help.obsidian.md/bases)
+- [JSON Canvas Spec](https://jsoncanvas.org/)
+
+## Contributing
+
+Contributions welcome! Please open an issue or pull request.
+
+## License
+
+MIT License - see [LICENSE](./LICENSE)

--- a/skills/json-canvas/SKILL.md
+++ b/skills/json-canvas/SKILL.md
@@ -1,5 +1,6 @@
 ---
 name: json-canvas
+version: "1.0.0"
 description: Create and edit JSON Canvas files (.canvas) with nodes, edges, groups, and connections. Use when working with .canvas files, creating visual canvases, mind maps, flowcharts, or when the user mentions Canvas files in Obsidian.
 ---
 

--- a/skills/obsidian-bases/SKILL.md
+++ b/skills/obsidian-bases/SKILL.md
@@ -1,5 +1,6 @@
 ---
 name: obsidian-bases
+version: "1.0.0"
 description: Create and edit Obsidian Bases (.base files) with views, filters, formulas, and summaries. Use when working with .base files, creating database-like views of notes, or when the user mentions Bases, table views, card views, filters, or formulas in Obsidian.
 ---
 

--- a/skills/obsidian-markdown/SKILL.md
+++ b/skills/obsidian-markdown/SKILL.md
@@ -1,5 +1,6 @@
 ---
 name: obsidian-markdown
+version: "1.0.0"
 description: Create and edit Obsidian Flavored Markdown with wikilinks, embeds, callouts, properties, and other Obsidian-specific syntax. Use when working with .md files in Obsidian, or when the user mentions wikilinks, callouts, frontmatter, tags, embeds, or Obsidian notes.
 ---
 


### PR DESCRIPTION
Hey @kepano great stuff here! Excited to see you dabbling with some of this stuff. I took the liberty to "upgrade" your setup to a proper Claude Code plugin so the skills could be more easily installed within CC. I've already got some skills that I've been working on for Obsidian, and will have a subsequent PR that you can have a look at, which might help. They add `references/` subdirs to the skills to reduce the core SKILL.md lines, and some other nice things that help with effective skill guidance.

## Changes

- Add .claude-plugin/plugin.json manifest (name: "obsidian", plugin sees `obsidian:obsidian-bases`)
- Move skills into `skills/` directory (leaves the door open for more Obsidian/Claude stuff like commands, hooks, etc.)
- Add version: "1.0.0" to all skill frontmatter. Claude needs versioning for the plugin to work properly.
- Update README with plugin installation instructions
