### PR TITLE
Replace backticked ! to avoid Claude Code bash permission error

### DIFF
--- a/obsidian-bases/SKILL.md
+++ b/obsidian-bases/SKILL.md
@@ -112,7 +112,7 @@ filters:
 | `<=` | less than or equal |
 | `&&` | logical and |
 | `\|\|` | logical or |
-| <code>!<code> | logical not |
+| <code>!</code> | logical not |
 
 ## Properties
 


### PR DESCRIPTION
### Summary

This PR updates `skills/obsidian-query-language.md`
to avoid using a backticked `!` operator.

Claude Code interprets `!` as a Bash execution prefix during permission
scanning and does not ignore markdown tables or inline code, which causes
the skill to fail loading with a permission error.

### Change

- Replace `` `!` `` with `<code>!</code>` in the Filter Operators table

### Notes

- Documentation-only change
- No semantic or functional impact on Obsidian usage
- Improves compatibility with Claude Code and similar agent runtimes

Fixes #10 
