### PR TITLE
clarify that Maps is a community plugin, not core

### DIFF
--- a/skills/obsidian-bases/SKILL.md
+++ b/skills/obsidian-bases/SKILL.md
@@ -354,7 +354,7 @@ views:
 
 ### Map View
 
-Requires latitude/longitude properties and the Maps plugin.
+Requires latitude/longitude properties and the Maps community plugin.
 
 ```yaml
 views:


### PR DESCRIPTION
This needs to be clarified, as the entire document is about core, built-in functionality except for Maps. It's doubly confusing for AI (and humans too), since Maps is the only plugin officially published by the Obsidian team.