### PR TITLE
docs: add sk installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,15 @@ Claude Skills for use with Obsidian.
 
 Add the contents of this repo to a `/.claude` folder in the root of your Obsidian vault (or whichever folder you're using with Claude Code). See more in the [official Claude Skills documentation](https://platform.claude.com/docs/en/agents-and-tools/agent-skills/overview).
 
+### Install with `sk`
+
+Install obsidian via [sk](https://github.com/803/skills-supply), the universal skills package manager for coding agents (supports Claude Code, Amp, Codex, OpenCode, etc...).
+
+```bash
+sk pkg add claude-plugin obsidian@kepano/obsidian-skills
+sk sync
+```
+
 ## Skills
 
 ### Create and edit Obsidian-compatible plain text files


### PR DESCRIPTION
`sk` is a package manager for agent skills (npm/cargo for agents). it works across most coding agents, handles updates, etc...

would you be open to adding this?
