### PR TITLE
Align skills with Agent Skills spec and Codex

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
-Claude Skills for use with Obsidian.
+Agent Skills for use with Obsidian.
+
+These skills follow the [Agent Skills specification](https://agentskills.io/specification) so they can be used by any skills-compatible agent, including Claude Code and Codex CLI.
 
 ## Installation
 
@@ -11,7 +13,13 @@ Claude Skills for use with Obsidian.
 
 ### Manually
 
+#### Claude Code
+
 Add the contents of this repo to a `/.claude` folder in the root of your Obsidian vault (or whichever folder you're using with Claude Code). See more in the [official Claude Skills documentation](https://platform.claude.com/docs/en/agents-and-tools/agent-skills/overview).
+
+#### Codex CLI
+
+Copy the `skills/` directory into your Codex skills path (typically `~/.codex/skills`). See the [Agent Skills specification](https://agentskills.io/specification) for the standard skill format.
 
 ## Skills
 

--- a/skills/json-canvas/SKILL.md
+++ b/skills/json-canvas/SKILL.md
@@ -5,7 +5,7 @@ description: Create and edit JSON Canvas files (.canvas) with nodes, edges, grou
 
 # JSON Canvas Skill
 
-This skill enables Claude Code to create and edit valid JSON Canvas files (`.canvas`) used in Obsidian and other applications.
+This skill enables skills-compatible agents to create and edit valid JSON Canvas files (`.canvas`) used in Obsidian and other applications.
 
 ## Overview
 
@@ -640,4 +640,3 @@ This format is a 16-character lowercase hex string (64-bit random value).
 
 - [JSON Canvas Spec 1.0](https://jsoncanvas.org/spec/1.0/)
 - [JSON Canvas GitHub](https://github.com/obsidianmd/jsoncanvas)
-

--- a/skills/obsidian-bases/SKILL.md
+++ b/skills/obsidian-bases/SKILL.md
@@ -5,7 +5,7 @@ description: Create and edit Obsidian Bases (.base files) with views, filters, f
 
 # Obsidian Bases Skill
 
-This skill enables Claude Code to create and edit valid Obsidian Bases (`.base` files) including views, filters, formulas, and all related configurations.
+This skill enables skills-compatible agents to create and edit valid Obsidian Bases (`.base` files) including views, filters, formulas, and all related configurations.
 
 ## Overview
 
@@ -616,4 +616,3 @@ filters:
 - [Functions](https://help.obsidian.md/bases/functions)
 - [Views](https://help.obsidian.md/bases/views)
 - [Formulas](https://help.obsidian.md/formulas)
-

--- a/skills/obsidian-markdown/SKILL.md
+++ b/skills/obsidian-markdown/SKILL.md
@@ -5,7 +5,7 @@ description: Create and edit Obsidian Flavored Markdown with wikilinks, embeds, 
 
 # Obsidian Flavored Markdown Skill
 
-This skill enables Claude Code to create and edit valid Obsidian Flavored Markdown, including all Obsidian-specific syntax extensions.
+This skill enables skills-compatible agents to create and edit valid Obsidian Flavored Markdown, including all Obsidian-specific syntax extensions.
 
 ## Overview
 
@@ -618,4 +618,3 @@ Internal notes:
 - [Embed files](https://help.obsidian.md/embeds)
 - [Callouts](https://help.obsidian.md/callouts)
 - [Properties](https://help.obsidian.md/properties)
-


### PR DESCRIPTION
## Description
- Update README to reference the Agent Skills specification and add Codex CLI install guidance.
- Make skill intros agent-neutral so the same skills work across Claude Code and Codex CLI.

## Why
- Moves the repo toward the [Agent Skills open standard](https://github.com/agentskills/agentskills) so the skills are portable across agents.
- Keeps changes minimal to ease review and merge.

## Files touched
- README.md
- skills/obsidian-markdown/SKILL.md
- skills/obsidian-bases/SKILL.md
- skills/json-canvas/SKILL.md

## Follow-up (optional)
- Split large SKILL.md files into references/ to align with the spec's recommendation to keep SKILL.md under 500 lines.