### PR TITLE
Add instructions about JSON newline escaping to avoid common mistakes

### DIFF
--- a/skills/json-canvas/SKILL.md
+++ b/skills/json-canvas/SKILL.md
@@ -69,6 +69,20 @@ Text nodes contain Markdown content.
 }
 ```
 
+#### Newline Escaping (Common Pitfall)
+
+In JSON, newline characters inside strings **must** be represented as `\n`. Do **not** use the literal sequence `\\n` in a `.canvas` file—Obsidian will render it as the characters `\` and `n` instead of a line break.
+
+Examples:
+
+```json
+{ "type": "text", "text": "Line 1\nLine 2" }
+```
+
+```json
+{ "type": "text", "text": "Line 1\\nLine 2" }
+```
+
 | Attribute | Required | Type | Description |
 |-----------|----------|------|-------------|
 | `text` | Yes | string | Plain text with Markdown syntax |


### PR DESCRIPTION
 Added a "Newline Escaping (Common Pitfall)" section to `skills/json-canvas/SKILL.md`, explaining that newlines in JSON strings must be represented as `\n`, and showing examples of correct and incorrect usage.