### PR TITLE
Add OpenCode setup instructions to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,18 @@ Add the contents of this repo to a `/.claude` folder in the root of your Obsidia
 
 Copy the `skills/` directory into your Codex skills path (typically `~/.codex/skills`). See the [Agent Skills specification](https://agentskills.io/specification) for the standard skill format.
 
+#### OpenCode
+
+Clone the entire repo into the OpenCode skills directory (`~/.opencode/skills/`):
+
+```sh
+git clone https://github.com/kepano/obsidian-skills.git ~/.opencode/skills/obsidian-skills
+```
+
+Do not copy only the inner `skills/` folder — clone the full repo so the directory structure is `~/.opencode/skills/obsidian-skills/skills/<skill-name>/SKILL.md`.
+
+OpenCode auto-discovers all `SKILL.md` files under `~/.opencode/skills/`. No changes to `opencode.json` or any config file are needed. Skills become available after restarting OpenCode.
+
 ## Skills
 
 | Skill | Description |


### PR DESCRIPTION
Adds installation instructions for OpenCode (https://github.com/opencode-ai/opencode) under the Manually section.

OpenCode auto-discovers `SKILL.md` files from `~/.opencode/skills/`. The instructions cover the exact git clone command, the expected directory structure, and note that no config changes are needed.