### PR TITLE
feat: add Gemini CLI extension support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+.DS_Store
+node_modules/
+.claude/
+.gemini/

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Add the contents of this repo to a `/.claude` folder in the root of your Obsidia
 Install the extension directly from the Git repository:
 
 ```sh
-gemini extensions install https://github.com/kepano/obsidian-skills
+gemini extensions install https://github.com/kepano/obsidian-skills --auto-update
 ```
 
 ### Codex CLI

--- a/README.md
+++ b/README.md
@@ -23,7 +23,15 @@ npx skills add git@github.com:kepano/obsidian-skills.git
 
 Add the contents of this repo to a `/.claude` folder in the root of your Obsidian vault (or whichever folder you're using with Claude Code). See more in the [official Claude Skills documentation](https://platform.claude.com/docs/en/agents-and-tools/agent-skills/overview).
 
-#### Codex CLI
+#### Gemini CLI
+
+Install the extension directly from the Git repository:
+
+```sh
+gemini extensions install https://github.com/kepano/obsidian-skills
+```
+
+### Codex CLI
 
 Copy the `skills/` directory into your Codex skills path (typically `~/.codex/skills`). See the [Agent Skills specification](https://agentskills.io/specification) for the standard skill format.
 

--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -1,0 +1,7 @@
+{
+  "name": "obsidian-skills",
+  "version": "1.0.1",
+  "description": "Create and edit Obsidian vault files including Markdown, Bases, and Canvas. Use when working with .md, .base, or .canvas files in an Obsidian vault.",
+  "repository": "https://github.com/kepano/obsidian-skills",
+  "license": "MIT"
+}


### PR DESCRIPTION
### Description

This PR adds native support for Gemini CLI, enabling users to install the Obsidian skills collection as a functional extension.

### Key changes:

- Added `gemini-extension.json`: The mandatory manifest file that allows Gemini CLI to recognize the repository as an extension and automatically discover all bundled skills in the skills/ directory.
- Updated `README.md`: Added clear installation instructions for Gemini CLI users, including the --auto-update flag for seamless synchronization with the repository.
- Added `.gitignore`: Included standard exclusions (e.g., .DS_Store, node_modules/) to maintain repository cleanliness across different agent environments.

### How to test this PR:

You can install and verify the extension directly from this branch using the following command:

```bash
gemini extensions install https://github.com/ikarenkov/obsidian-skills --ref feat/gemini-support
``` 
> Note: When prompted to "attempt to install via 'git clone' instead", please answer Y.

Example of installation flow:

<img width="1242" height="797" alt="Screenshot 2026-03-21 at 17 27 00" src="https://github.com/user-attachments/assets/6f4f6912-05a5-4440-b15e-685727eda7b6" />

### Test results:
- ✅ Installation: The extension installs successfully via git clone fallback.
- ✅ Discovery: Gemini CLI correctly identifies and lists the extension.
- ✅ Skills Registration: All bundled skills (obsidian-markdown, obsidian-bases, json-canvas, obsidian-cli, defuddle) are automatically discovered and available.
- ✅ Functionality: Verified that the agent correctly activates the relevant skills when prompted with Obsidian-specific tasks.

