### PR TITLE
docs: add bases embed examples

### DIFF
--- a/skills/obsidian-markdown/references/EMBEDS.md
+++ b/skills/obsidian-markdown/references/EMBEDS.md
@@ -38,6 +38,13 @@
 ![[document.pdf#height=400]]
 ```
 
+## Embed Bases
+
+```markdown
+![[BaseFile.base]]
+![[BaseFile.base#View Name]]
+```
+
 ## Embed Lists
 
 ```markdown


### PR DESCRIPTION
## Summary
- add a Base embed example to the embeds reference
- include the syntax for embedding a specific Base view
- align the examples with the existing obsidian-bases skill documentation

## Testing
- ran \