### PR TITLE
defuddle: skip URLs ending in .md

### DIFF
--- a/skills/defuddle/SKILL.md
+++ b/skills/defuddle/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: defuddle
-description: Extract clean markdown content from web pages using Defuddle CLI, removing clutter and navigation to save tokens. Use instead of WebFetch when the user provides a URL to read or analyze, for online documentation, articles, blog posts, or any standard web page.
+description: Extract clean markdown content from web pages using Defuddle CLI, removing clutter and navigation to save tokens. Use instead of WebFetch when the user provides a URL to read or analyze, for online documentation, articles, blog posts, or any standard web page. Do NOT use for URLs ending in .md — those are already markdown, use WebFetch directly.
 ---
 
 # Defuddle


### PR DESCRIPTION
## Summary

Documentation sites increasingly serve raw markdown at `.md` URLs (part of the [llms.txt](https://llmstxt.org/) ecosystem, started late 2024). Platforms like Mintlify, GitBook, and Cloudflare enabled this for thousands of sites. Stripe, Docker, Vercel, Anthropic all support it.

Since these URLs already return markdown, running them through Defuddle is redundant — WebFetch is sufficient.

Examples:
- https://docs.docker.com/ai/sandboxes.md
- https://code.claude.com/docs/en/devcontainer.md
- https://docs.stripe.com/building-with-llms.md