### PR TITLE
docs(obsidian-bases): fix invalid filter schema example

### DIFF
--- a/skills/obsidian-bases/SKILL.md
+++ b/skills/obsidian-bases/SKILL.md
@@ -22,10 +22,11 @@ Base files use the `.base` extension and contain valid YAML.
 # Global filters apply to ALL views in the base
 filters:
   # Can be a single filter string
-  # OR a recursive filter object with and/or/not
-  and: []
-  or: []
-  not: []
+  # OR a recursive filter object with exactly ONE key: and, or, or not
+  and:
+    - 'status == "active"'
+    - not:
+        - 'file.hasTag("archived")'
 
 # Define formula properties that can be used across all views
 formulas:
@@ -52,8 +53,9 @@ views:
     groupBy:                     # Optional: group results
       property: property_name
       direction: ASC | DESC
-    filters:                     # View-specific filters
-      and: []
+    filters:                     # View-specific filters follow the same rules
+      and:
+        - 'status == "active"'
     order:                       # Properties to display in order
       - file.name
       - property_name


### PR DESCRIPTION
## Summary
- fix the top-level  schema example so it no longer shows , , and  as sibling keys
- update the view-level example to follow the same valid nested filter structure

Closes #58.