### PR TITLE
Restrict defuddle skill to Bash(defuddle:*)

### DIFF
--- a/skills/defuddle/SKILL.md
+++ b/skills/defuddle/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: defuddle
 description: Extract clean markdown content from web pages using Defuddle CLI, removing clutter and navigation to save tokens. Use instead of WebFetch when the user provides a URL to read or analyze, for online documentation, articles, blog posts, or any standard web page. Do NOT use for URLs ending in .md — those are already markdown, use WebFetch directly.
+allowed-tools: Bash(defuddle:*)
 ---
 
 # Defuddle


### PR DESCRIPTION
Adds `allowed-tools: Bash(defuddle:*)` to the defuddle skill frontmatter so the skill declares it only needs to shell out to the `defuddle` binary.