### PR TITLE
ci: add Tessl skill-review-and-optimize workflow with /apply-optimize

### DIFF
--- a/.github/workflows/skill-optimize-apply.yml
+++ b/.github/workflows/skill-optimize-apply.yml
@@ -1,0 +1,25 @@
+# Apply Skill Optimization — triggered when a contributor comments /apply-optimize on a PR.
+# Commits the AI-suggested SKILL.md improvements from the review step directly to the branch.
+# Docs: https://github.com/tesslio/skill-review-and-optimize
+name: Apply Skill Optimization
+
+on:
+  issue_comment:
+    types: [created]
+
+jobs:
+  apply:
+    if: >
+      github.event.issue.pull_request &&
+      contains(github.event.comment.body, '/apply-optimize')
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: tesslio/skill-review-and-optimize@bff9490027d60847df6494fdac7dccfb3ad82948
+        with:
+          mode: apply

--- a/.github/workflows/skill-review.yml
+++ b/.github/workflows/skill-review.yml
@@ -1,0 +1,26 @@
+# Tessl Skill Review & Optimize — runs on PRs that change any SKILL.md.
+# Posts scores and AI-suggested improvements as a single PR comment.
+# Contributors can comment /apply-optimize to commit the suggestions automatically.
+# Docs: https://github.com/tesslio/skill-review-and-optimize
+name: Tessl Skill Review & Optimize
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - "**/SKILL.md"
+
+jobs:
+  review:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+      - uses: tesslio/skill-review-and-optimize@bff9490027d60847df6494fdac7dccfb3ad82948
+        with:
+          optimize: true
+          tessl-token: ${{ secrets.TESSL_API_TOKEN }}
+          # Optional quality gate (off by default):
+          # fail-threshold: 70


### PR DESCRIPTION
Hey @kepano 👋

Following up on the skill quality improvements PR that was merged — this adds a GitHub Action that **automatically reviews and optimizes `SKILL.md` files on future PRs**, so your skills stay sharp as Obsidian evolves without manual effort.

## What this adds

**`.github/workflows/skill-review.yml`** — runs on every PR that touches a `SKILL.md`:
- Posts Tessl scores + AI-suggested improved skill content as a single PR comment
- Uses [`tesslio/skill-review-and-optimize`](https://github.com/tesslio/skill-review-and-optimize)

**`.github/workflows/skill-optimize-apply.yml`** — triggered by a `/apply-optimize` comment on a PR:
- Commits the AI-suggested improvements directly to the PR branch — no copy-paste needed

## 🔑 One-time setup required

Add a `TESSL_API_TOKEN` secret to this repo:
**Settings → Secrets and variables → Actions → New repository secret**

Get a free token at https://tessl.io/account/api-keys.

> Without the token the action still posts review scores and feedback — just without the AI optimization suggestions.

## What stays the same

- **Non-blocking by default** — no red CI unless you add `fail-threshold`
- **Only fires on `**/SKILL.md` PRs** — no noise on other changes
- **Contributors need no Tessl account** — only the repo owner needs the API token for optimization

---

Honest disclosure — I work at @tesslio where we build tooling around skills like these. Not a pitch — just saw room for improvement and wanted to contribute.

Want to self-improve your skills? Just point your agent (Claude Code, Codex, etc.) at [this Tessl guide](https://docs.tessl.io/evaluate/optimize-a-skill-using-best-practices) and ask it to optimize your skill. Ping me — [@popey](https://github.com/popey) — if you hit any snags.

Thanks in advance 🙏