### PR TITLE
docs(obsidian-cli): sync with current CLI behavior

### DIFF
--- a/skills/obsidian-cli/SKILL.md
+++ b/skills/obsidian-cli/SKILL.md
@@ -9,7 +9,7 @@ Use the `obsidian` CLI to interact with a running Obsidian instance. Requires Ob
 
 ## Command reference
 
-Run `obsidian help` to see all available commands. This is always up to date. Full docs: https://help.obsidian.md/cli
+Run `obsidian help` to see all available commands. Use `obsidian help <command>` (or `obsidian <command> --help`) for detailed help on a specific command. Full docs: https://help.obsidian.md/cli
 
 ## Syntax
 
@@ -22,17 +22,20 @@ obsidian create name="My Note" content="Hello world"
 **Flags** are boolean switches with no value:
 
 ```bash
-obsidian create name="My Note" silent overwrite
+obsidian create name="My Note" open overwrite
 ```
 
 For multiline content use `\n` for newline and `\t` for tab.
 
 ## File targeting
 
-Many commands accept `file` or `path` to target a file. Without either, the active file is used.
+Many commands accept `file` or `path` to target a file. Without either:
+- **Content commands** (`read`, `outline`, `append`, `rename`, etc.) default to the active file.
+- **List/aggregation commands** (`aliases`, `properties`, `tags`, `tasks`) default to vault-wide; use the `active` flag to scope them to the active file.
 
 - `file=<name>` — resolves like a wikilink (name only, no path or extension needed)
 - `path=<path>` — exact path from vault root, e.g. `folder/note.md`
+- `active` — scope list/aggregation commands to the active file
 
 ## Vault targeting
 
@@ -46,10 +49,15 @@ obsidian vault="My Vault" search query="test"
 
 ```bash
 obsidian read file="My Note"
-obsidian create name="New Note" content="# Hello" template="Template" silent
+obsidian create name="New Note" content="# Hello" template="Template"
+obsidian create name="New Note" content="# Hello" open  # also open in Obsidian
 obsidian append file="My Note" content="New line"
+obsidian rename file="Old Name" name="New Name"
+obsidian move path="folder/Old.md" to="other/Old.md"  # to= must include filename, not just a folder
 obsidian search query="search term" limit=10
+obsidian search:context query="search term"  # includes surrounding context
 obsidian daily:read
+obsidian daily:path                          # get expected daily note path
 obsidian daily:append content="- [ ] New task"
 obsidian property:set name="status" value="done" file="My Note"
 obsidian tasks daily todo
@@ -57,7 +65,7 @@ obsidian tags sort=count counts
 obsidian backlinks file="My Note"
 ```
 
-Use `--copy` on any command to copy output to clipboard. Use `silent` to prevent files from opening. Use `total` on list commands to get a count.
+Commands default to **silent operation** — files are not opened in Obsidian unless you add the `open` flag. Use `--copy` on any command to copy output to clipboard. Use `total` on list commands to get a count.
 
 ## Plugin development
 


### PR DESCRIPTION
## Summary

The obsidian-cli SKILL.md had drifted from the CLI's current behavior. This PR updates the documentation to match what the CLI actually does (verified empirically on the current release) and adds commonly-used command examples.

## Changes

**Behavior corrections (each verified by running the command):**

- `silent` flag no longer exists in the CLI. Replaced `silent overwrite` example with `open overwrite` (the explicit opt-in flag). The trailing note is reworded to reflect that silent is now the default.
- File targeting: the previous wording ("Without either, the active file is used") was only true for content commands. List/aggregation commands (`aliases`, `properties`, `tags`, `tasks`) default to **vault-wide** and require the `active` flag to scope to the active file. Verified:
  - `obsidian properties` (no args) → vault-wide property list
  - `obsidian properties active` → active note's frontmatter
  - `obsidian tags` / `tags active` → same pattern
  - `obsidian read` / `outline` (no args) → active file content (content default)
- `active` flag is now documented.

**New command examples in Common patterns:**
- `rename` — rename a file
- `move` — move/relocate a file
- `search:context` — search with surrounding context
- `daily:path` — get expected daily note path
- `create ... open` — create and open in one step

**`obsidian move` quirk documented:**

`to=` must be a full destination path including the filename. Passing a folder (with or without trailing slash) fails with "Destination file already exists." Verified:
- `to="folder/"` → error
- `to="folder"` → error
- `to="folder/file.md"` → success

The command's `--help` says `to=<path>` with the description "Destination folder or path (required)", but in practice only a full file path works.

**Documentation tip:**
- Added a note about `obsidian help <command>` (or `<command> --help`) for per-command detail.

## Test plan

- [x] Verified `silent` flag is absent from current CLI help (`obsidian create --help`)
- [x] Verified `open` flag exists on `create` and works as opt-in
- [x] Verified content commands (`read`, `outline`) default to active file
- [x] Verified list commands (`aliases`, `properties`, `tags`, `tasks`) default to vault-wide
- [x] Verified `active` flag scopes list commands to active file
- [x] Verified `obsidian move` folder-target failure and filename workaround
