### PR TITLE
docs: clarify properties prefix rule and add CLI/Bases prerequisites

### DIFF
--- a/skills/obsidian-bases/SKILL.md
+++ b/skills/obsidian-bases/SKILL.md
@@ -5,6 +5,10 @@ description: Create and edit Obsidian Bases (.base files) with views, filters, f
 
 # Obsidian Bases Skill
 
+## Prerequisite
+
+Bases is a **core plugin** introduced in Obsidian v1.9, but it is **not always enabled by default** — particularly in vaults that predate v1.9. If `.base` files don't appear in the file tree or won't render, check that `.obsidian/core-plugins.json` contains `"bases": true`. Enable via Settings → Core plugins → Bases, or edit the JSON and reload the vault.
+
 ## Workflow
 
 1. **Create the file**: Create a `.base` file in the vault with valid YAML content
@@ -31,13 +35,15 @@ filters:
 formulas:
   formula_name: 'expression'
 
-# Configure display names and settings for properties
+# Configure display names and settings for properties.
+# IMPORTANT: keys in this section must use their fully-qualified form.
+# Frontmatter properties need the `note.` prefix or the displayName is silently ignored.
 properties:
-  property_name:
+  note.property_name:        # frontmatter property — MUST prefix with `note.`
     displayName: "Display Name"
-  formula.formula_name:
+  formula.formula_name:      # formula reference — already prefixed
     displayName: "Formula Display Name"
-  file.ext:
+  file.ext:                  # file property — already prefixed
     displayName: "Extension"
 
 # Define custom summary formulas
@@ -122,6 +128,8 @@ filters:
 1. **Note properties** - From frontmatter: `note.author` or just `author`
 2. **File properties** - File metadata: `file.name`, `file.mtime`, etc.
 3. **Formula properties** - Computed values: `formula.my_formula`
+
+**Asymmetric prefix rule**: in `order`, `filters`, `groupBy`, and `sort`, a frontmatter property can be referenced bare (`author`) or prefixed (`note.author`). But in the top-level `properties:` configuration block (where `displayName` is set), frontmatter keys **must** use the `note.` prefix — bare keys are silently ignored and the raw field name will appear as the column header. See Troubleshooting for the symptom.
 
 ### File Properties Reference
 
@@ -302,7 +310,7 @@ formulas:
   priority_label: 'if(priority == 1, "🔴 High", if(priority == 2, "🟡 Medium", "🟢 Low"))'
 
 properties:
-  status:
+  note.status:
     displayName: Status
   formula.days_until_due:
     displayName: "Days Until Due"
@@ -351,7 +359,7 @@ formulas:
   year_read: 'if(finished_date, date(finished_date).year, "")'
 
 properties:
-  author:
+  note.author:
     displayName: Author
   formula.status_icon:
     displayName: ""
@@ -475,6 +483,22 @@ formulas:
 # CORRECT - guard with if()
 'if(due_date, (date(due_date) - today()).days, "")'
 ```
+
+**`displayName` ignored / column shows raw field name**: in the `properties:` configuration block, frontmatter keys must be prefixed with `note.`. Bare keys are silently ignored.
+
+```yaml
+# WRONG - displayName ignored, column header shows "status"
+properties:
+  status:
+    displayName: Status
+
+# CORRECT - column header shows "Status"
+properties:
+  note.status:
+    displayName: Status
+```
+
+This asymmetry trips users up because `order`, `filters`, and `groupBy` all accept the bare form. The `properties:` block is the exception.
 
 **Referencing undefined formulas**: Ensure every `formula.X` in `order` or `properties` has a matching entry in `formulas`.
 

--- a/skills/obsidian-cli/SKILL.md
+++ b/skills/obsidian-cli/SKILL.md
@@ -7,6 +7,42 @@ description: Interact with Obsidian vaults using the Obsidian CLI to read, creat
 
 Use the `obsidian` CLI to interact with a running Obsidian instance. Requires Obsidian to be open.
 
+## Prerequisites
+
+The `obsidian` binary ships with the **installer**, not with the auto-updated asar bundle. If `which obsidian` returns nothing, the user is most likely missing one of these:
+
+1. **Installer is too old.** Obsidian on macOS has two version numbers: the asar bundle (shown in Settings → About) auto-updates, but the installer at `/Applications/Obsidian.app` does **not**. The in-app "check for updates" only covers the asar — it can report "you are on the latest version" while the installer is multiple versions behind. CLI binary requires installer ≥ 1.10. Check via:
+
+   ```bash
+   defaults read /Applications/Obsidian.app/Contents/Info.plist CFBundleShortVersionString
+   ```
+
+   If old, download the latest from <https://obsidian.md/download> and reinstall (vault data is unaffected).
+
+2. **CLI not enabled.** Settings → General → Advanced → toggle "Enable command line interface" ON. This installs the shim to `/usr/local/bin/`.
+
+3. **PATH not refreshed.** Open a new terminal after enabling.
+
+### Health check
+
+```bash
+which obsidian \
+  && obsidian vault \
+  && obsidian dev:screenshot path=/tmp/obs.png
+```
+
+If all three succeed, the CLI is ready.
+
+### Fallback when CLI is unavailable
+
+When the CLI cannot be installed (older Obsidian, restricted host, etc.), most vault operations are still doable via direct file access:
+
+- Read / edit notes: read or edit the `.md` file directly
+- Toggle core plugins: edit `.obsidian/core-plugins.json` and ask the user to reload (`Cmd+P → Reload app without saving`)
+- Open a file: `open "obsidian://open?vault=<name>&file=<url-encoded-path>"`
+
+Note: direct file edits won't trigger Obsidian's index refresh until the vault reloads.
+
 ## Command reference
 
 Run `obsidian help` to see all available commands. This is always up to date. Full docs: https://help.obsidian.md/cli


### PR DESCRIPTION
## Summary

Two documentation fixes informed by hands-on use that hit real gotchas.

### `obsidian-bases`: the `properties:` prefix asymmetry is silent

In `order`, `filters`, `groupBy`, and `sort`, frontmatter properties can be referenced bare (`status`) or prefixed (`note.status`) — both work.

But in the top-level `properties:` configuration block, the bare form is **silently ignored**: `displayName` does not apply, and the column header shows the raw frontmatter field name. The asymmetry isn't documented anywhere and is hard to debug because there's no error or warning.

This PR:
- Adds an explicit "asymmetric prefix rule" note in the Properties section
- Updates the Schema example and the Task Tracker / Reading List examples to use `note.<field>` in their `properties:` blocks
- Adds a Troubleshooting entry showing the wrong-vs-right pattern

### `obsidian-bases`: Bases plugin may not be enabled

Bases is a core plugin since v1.9, but in vaults that predate v1.9 the plugin can be **disabled by default** — `core-plugins.json` may show `"bases": false`. The symptom is that `.base` files don't appear in the file tree at all and macOS Finder asks "what app should open this?" when double-clicked. Added a one-paragraph Prerequisite note.

### `obsidian-cli`: the "latest version" trap on macOS

Obsidian on macOS has two independent version numbers:
- The asar bundle (shown in Settings → About) auto-updates
- The installer at `/Applications/Obsidian.app` does **not**

The in-app "check for updates" only covers the asar. So you can be on "latest 1.12.7" by Settings, but still have a stale installer that lacks the CLI binary, and `which obsidian` returns nothing.

Added a Prerequisites section that documents:
- The two-version-number gotcha + how to check the installer version
- The "Enable command line interface" Settings toggle requirement
- A health-check command
- A fallback path (direct file edits + URI scheme) for environments where the CLI cannot be installed

## Scope

Documentation only. No behavior changes, no formula/syntax changes. Two files modified.

## Test plan

- [x] Reproduced the `displayName` silent-ignore symptom on Obsidian 1.12.7 with bare frontmatter keys; confirmed `note.<field>` fixes it
- [x] Reproduced the macOS installer/asar version mismatch on a system that auto-updated to 1.12.7 asar but had a 1.8.4 installer with no CLI binary
- [x] Reproduced the disabled-Bases-plugin case in a v1.8 vault that auto-updated; `core-plugins.json` showed `"bases": false`

🤖 Generated with [Claude Code](https://claude.com/claude-code)