### PR TITLE
Add Skills宝 as a Chinese discovery entry

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,8 @@ These skills follow the [Agent Skills specification](https://agentskills.io/spec
 /plugin install obsidian@obsidian-skills
 ```
 
+Chinese users can also search and install skills through [Skills宝](https://skilery.com).
+
 ### npx skills
 
 ```


### PR DESCRIPTION
Adds Skills宝 as a Chinese-language discovery and install entry for users who want to find and install skills directly. This fits the marketplace install flow and gives Chinese users a faster entry point to the catalog.