### PR TITLE
feat(obsidian-cli): expand SKILL.md with comprehensive command coverage

### DIFF
--- a/skills/obsidian-cli/SKILL.md
+++ b/skills/obsidian-cli/SKILL.md
@@ -44,20 +44,176 @@ obsidian vault="My Vault" search query="test"
 
 ## Common patterns
 
+### Notes
+
 ```bash
 obsidian read file="My Note"
 obsidian create name="New Note" content="# Hello" template="Template" silent
 obsidian append file="My Note" content="New line"
+obsidian prepend file="My Note" content="Header line"
+obsidian delete file="My Note"
+obsidian open file="My Note"
+obsidian move path="old/note.md" file="new/note.md"
+obsidian rename file="Old Name" name="New Name"
+```
+
+### Search
+
+```bash
 obsidian search query="search term" limit=10
+obsidian search:context query="search term" limit=10
+obsidian search:open query="search term"
+```
+
+### Daily notes
+
+```bash
+obsidian daily
 obsidian daily:read
 obsidian daily:append content="- [ ] New task"
+obsidian daily:prepend content="# Morning thoughts"
+obsidian daily:path
+```
+
+### Properties
+
+```bash
 obsidian property:set name="status" value="done" file="My Note"
+obsidian property:read name="status" file="My Note"
+obsidian property:remove name="status" file="My Note"
+obsidian properties sort=count counts
+```
+
+### Tasks
+
+```bash
 obsidian tasks daily todo
+obsidian task file="My Note" line=5 toggle
+```
+
+### Tags and links
+
+```bash
 obsidian tags sort=count counts
+obsidian tag name="my-tag"
 obsidian backlinks file="My Note"
+obsidian links file="My Note"
+obsidian orphans
+obsidian deadends
+obsidian unresolved
+```
+
+### Files and folders
+
+```bash
+obsidian files
+obsidian folders
+obsidian file file="My Note"
+obsidian folder path="My Folder"
+obsidian recents
+obsidian random
+obsidian random:read
+obsidian wordcount file="My Note"
+```
+
+### Templates
+
+```bash
+obsidian templates
+obsidian template:read name="My Template"
+obsidian template:insert name="My Template"
+```
+
+### Bookmarks
+
+```bash
+obsidian bookmarks
+obsidian bookmark file="My Note" title="Important"
+```
+
+### Commands
+
+```bash
+obsidian commands
+obsidian command id="workspace:close"
+obsidian hotkeys
+obsidian hotkey id="workspace:close"
+```
+
+### Workspace
+
+```bash
+obsidian workspace
+obsidian tabs
+obsidian tab:open
+obsidian outline
+obsidian reload
+obsidian restart
+```
+
+### Vault
+
+```bash
+obsidian vault
+obsidian vaults
+obsidian version
 ```
 
 Use `--copy` on any command to copy output to clipboard. Use `silent` to prevent files from opening. Use `total` on list commands to get a count.
+
+## Bases (databases)
+
+```bash
+obsidian bases
+obsidian base:query file="My Base" view="All"
+obsidian base:create file="My Base" view="All" name="New Item"
+obsidian base:views file="My Base"
+```
+
+## Plugins and themes
+
+```bash
+obsidian plugins
+obsidian plugins:enabled
+obsidian plugin id="dataview"
+obsidian plugin:enable id="dataview"
+obsidian plugin:disable id="dataview"
+obsidian plugin:install id="dataview"
+obsidian plugin:uninstall id="dataview"
+obsidian plugins:restrict
+obsidian themes
+obsidian theme
+obsidian theme:set name="Minimal"
+obsidian theme:install name="Minimal"
+obsidian theme:uninstall name="Minimal"
+obsidian snippets
+obsidian snippets:enabled
+obsidian snippet:enable name="custom"
+obsidian snippet:disable name="custom"
+```
+
+## Sync
+
+```bash
+obsidian sync:status
+obsidian sync
+obsidian sync:history path="note.md"
+obsidian sync:read path="note.md" version=3
+obsidian sync:restore path="note.md" version=3
+obsidian sync:deleted
+obsidian sync:open
+obsidian diff path="note.md"
+```
+
+## History (file recovery)
+
+```bash
+obsidian history:list
+obsidian history path="note.md"
+obsidian history:read path="note.md" version=3
+obsidian history:restore path="note.md" version=3
+obsidian history:open
+```
 
 ## Plugin development
 
@@ -101,6 +257,13 @@ Toggle mobile emulation:
 
 ```bash
 obsidian dev:mobile on
+```
+
+Debug with Chrome DevTools Protocol:
+
+```bash
+obsidian dev:debug
+obsidian dev:cdp method="Runtime.evaluate" params='{"expression": "app.vault.getName()"}'
 ```
 
 Run `obsidian help` to see additional developer commands including CDP and debugger controls.


### PR DESCRIPTION
## Summary

This PR significantly expands the `obsidian-cli` SKILL.md to cover the full range of commands available in Obsidian CLI v1.12.x, making the skill more useful for Claude Code users working with Obsidian vaults.

## What's New

### Common Patterns (reorganized into sections)
- **Notes**: `prepend`, `delete`, `open`, `move`, `rename`
- **Search**: `search:context`, `search:open`
- **Daily notes**: `daily`, `daily:prepend`, `daily:path`
- **Properties**: `property:read`, `property:remove`, `properties`
- **Tasks**: `task` (toggle)
- **Tags & Links**: `tag`, `links`, `orphans`, `deadends`, `unresolved`
- **Files & Folders**: `files`, `folders`, `file`, `folder`, `recents`, `random`, `wordcount`
- **Templates**: `templates`, `template:read`, `template:insert`
- **Bookmarks**: `bookmarks`, `bookmark`
- **Commands**: `commands`, `command`, `hotkeys`, `hotkey`
- **Workspace**: `workspace`, `tabs`, `tab:open`, `outline`, `reload`, `restart`
- **Vault**: `vault`, `vaults`, `version`

### New Sections
- **Bases (databases)**: `bases`, `base:query`, `base:create`, `base:views`
- **Plugins & Themes**: full enable/disable/install/uninstall coverage + snippets
- **Sync**: `sync:status`, `sync:history`, `sync:read`, `sync:restore`, `sync:deleted`, `diff`
- **History (file recovery)**: `history:list`, `history:read`, `history:restore`
- **Plugin Dev**: added CDP debugging (`dev:debug`, `dev:cdp`)

## Testing

All commands were verified against `obsidian help` output from Obsidian v1.12.7.