### PR TITLE
Add skill: heyneuron/flowhunt-skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,3 +54,17 @@ OpenCode auto-discovers all `SKILL.md` files under `~/.opencode/skills/`. No cha
 | [json-canvas](skills/json-canvas) | Create and edit [JSON Canvas](https://jsoncanvas.org/) files (`.canvas`) with nodes, edges, groups, and connections |
 | [obsidian-cli](skills/obsidian-cli) | Interact with Obsidian vaults via the [Obsidian CLI](https://help.obsidian.md/cli) including plugin and theme development |
 | [defuddle](skills/defuddle) | Extract clean markdown from web pages using [Defuddle](https://github.com/kepano/defuddle-cli), removing clutter to save tokens |
+
+## Community Skills
+
+Skills built by the community that follow the Agent Skills specification and are compatible with Claude Code, Codex CLI, and other skills-compatible agents.
+
+| Skill | Description |
+|-------|-------------|
+| [heyneuron/flowhunt-skill](https://github.com/heyneuron/flowhunt-skill) | Automation discovery audit — walks through a 5-question workflow intake and audits Gmail, Calendar, Slack, and task trackers to identify automation opportunities |
+
+Install with:
+
+```
+npx skills add heyneuron/flowhunt-skill
+```


### PR DESCRIPTION
## Summary

Adds a new **Community Skills** section to the README with an entry for [heyneuron/flowhunt-skill](https://github.com/heyneuron/flowhunt-skill).

**FlowHunt Skill** is an automation discovery audit skill. It walks through a 5-question workflow intake and audits Gmail, Calendar, Slack, and task trackers to identify automation opportunities.

Install:
```
npx skills add heyneuron/flowhunt-skill
```

The skill follows the [Agent Skills specification](https://agentskills.io/specification) and is compatible with Claude Code, Codex CLI, and other skills-compatible agents.

> This PR was created with Claude Code assistance.