### PR TITLE
docs(obsidian-cli): add platform setup notes for WSL and headless Linux

### DIFF
--- a/skills/obsidian-cli/SKILL.md
+++ b/skills/obsidian-cli/SKILL.md
@@ -7,6 +7,24 @@ description: Interact with Obsidian vaults using the Obsidian CLI to read, creat
 
 Use the `obsidian` CLI to interact with a running Obsidian instance. Requires Obsidian to be open.
 
+## Platform setup
+
+> [!info] WSL / Windows
+> When invoking from WSL, point your wrapper at `Obsidian.com` (the Electron console stub), not `Obsidian.exe`. The `.exe` is a GUI-subsystem binary and silently drops stdout/stderr, so subcommands appear to succeed but produce no output:
+>
+> ```bash
+> # ~/bin/obsidian
+> "/mnt/c/Program Files/Obsidian/Obsidian.com" "$@"
+> ```
+
+> [!info] Headless Linux
+> On Linux without a display (servers, Docker, CI), run Obsidian under Xvfb and set `DISPLAY` to match:
+>
+> ```bash
+> Xvfb :99 -screen 0 1024x768x24 &
+> DISPLAY=:99 obsidian version
+> ```
+
 ## Command reference
 
 Run `obsidian help` to see all available commands. This is always up to date. Full docs: https://help.obsidian.md/cli


### PR DESCRIPTION
﻿## Summary

Adds a **Platform setup** section to the obsidian-cli skill covering two environment-specific pitfalls that currently have no guidance in the skill.

Closes #93
Closes #62

## Changes

### WSL / Windows (#93)

`Obsidian.exe` is a GUI-subsystem binary. When invoked from WSL it returns exit code 0 but silently drops all stdout/stderr. The fix is to use `Obsidian.com`, the Electron console stub that ships alongside `.exe` and pipes streams correctly.

### Headless Linux (#62)

On Linux without a display (servers, Docker, CI), the CLI fails unless DISPLAY is set to match the Xvfb display where Obsidian is running.

Both issue reporters explicitly offered to submit a PR but never did.
