### PR TITLE
fix(json-canvas): document double-quote escaping pitfall in text content

### DIFF
--- a/skills/json-canvas/SKILL.md
+++ b/skills/json-canvas/SKILL.md
@@ -92,6 +92,16 @@ Nodes are objects placed on the canvas. Array order determines z-index: first no
 
 **Newline pitfall**: Use `\n` for line breaks in JSON strings. Do **not** use the literal `\\n` -- Obsidian renders that as the characters `\` and `n`.
 
+**Quote pitfall**: Escape double quotes inside JSON string values as `\"`. Unescaped quotes produce invalid JSON that Obsidian cannot render:
+
+```json
+// ❌ Invalid — unescaped quotes break JSON syntax
+"text": "She said "hello world""
+
+// ✅ Valid — quotes escaped
+"text": "She said \"hello world\""
+```
+
 ### File Nodes
 
 | Attribute | Required | Type | Description |
@@ -232,7 +242,7 @@ After creating or editing a canvas file, verify:
 7. Color presets are `"1"` through `"6"` or valid hex (e.g., `"#FF0000"`)
 8. JSON is valid and parseable
 
-If validation fails, check for duplicate IDs, dangling edge references, or malformed JSON strings (especially unescaped newlines in text content).
+If validation fails, check for duplicate IDs, dangling edge references, or malformed JSON strings (especially unescaped double quotes or newlines in text content).
 
 ## Complete Examples
 


### PR DESCRIPTION
﻿## Summary

Documents the double-quote escaping requirement in JSON Canvas text content.

Closes #42

## Problem

Double quotes inside JSON string values must be escaped as `\"` to produce valid JSON. Without this, canvas files containing quoted text (e.g. `"公司的"外交官""` or `"She said "hello""` ) are silently broken — Obsidian renders them as empty or displays errors.

## Changes

- Adds a **Quote pitfall** note with ❌/✅ examples directly after the existing **Newline pitfall** in the Text Nodes section (consistent style)
- Updates the Validation Checklist footer to mention unescaped double quotes alongside unescaped newlines
