### PR TITLE
docs(obsidian-cli): warn that npx obsidian-cli is an unrelated npm package

### DIFF
--- a/skills/obsidian-cli/SKILL.md
+++ b/skills/obsidian-cli/SKILL.md
@@ -7,6 +7,9 @@ description: Interact with Obsidian vaults using the Obsidian CLI to read, creat
 
 Use the `obsidian` CLI to interact with a running Obsidian instance. Requires Obsidian to be open.
 
+> [!warning] Not `npx obsidian-cli`
+> The npm package `obsidian-cli` (`npx obsidian-cli`) is **not** the official Obsidian CLI — it is an unrelated QA testing tool that requires `OBSIDIAN_API_KEY` and `OBSIDIAN_API_SECRET`. Use the `obsidian` command that ships with the Obsidian desktop app (Obsidian 1.7+). See https://help.obsidian.md/cli for setup.
+
 ## Command reference
 
 Run `obsidian help` to see all available commands. This is always up to date. Full docs: https://help.obsidian.md/cli


### PR DESCRIPTION
## Summary

The npm package `obsidian-cli` (installed via `npx obsidian-cli`) is a completely unrelated QA testing tool that requires `OBSIDIAN_API_KEY` and `OBSIDIAN_API_SECRET`. Users who discover this skill and try `npx obsidian-cli` instead of the Obsidian desktop app CLI get a confusing authentication error and cannot proceed.

This adds a callout near the top of the skill to redirect them to the official CLI before they waste time debugging.

Fixes #47

## Changes

- `skills/obsidian-cli/SKILL.md`: add `[!warning]` callout clarifying that `npx obsidian-cli` is not the official Obsidian CLI, and pointing to https://help.obsidian.md/cli