### PR TITLE
docs(json-canvas): add CJK sizing guidance and file path escape pitfall

### DIFF
--- a/skills/json-canvas/SKILL.md
+++ b/skills/json-canvas/SKILL.md
@@ -111,6 +111,16 @@ Nodes are objects placed on the canvas. Array order determines z-index: first no
 }
 ```
 
+**File path pitfall**: If a file name contains double quotes (e.g. `He said "hello".md`), hand-writing the JSON will produce invalid output. Use a shell command with `json.dump` to build the canvas safely:
+
+```bash
+python3 -c "
+import json
+canvas = {'nodes': [{'id': 'abc1', 'type': 'file', 'x': 0, 'y': 0, 'width': 400, 'height': 300, 'file': 'He said \"hello\".md'}], 'edges': []}
+print(json.dumps(canvas, ensure_ascii=False))
+" > my.canvas
+```
+
 ### Link Nodes
 
 | Attribute | Required | Type | Description |
@@ -218,6 +228,8 @@ Generate 16-character lowercase hexadecimal strings (64-bit random value):
 | Large text | 400-600 | 300-500 |
 | File preview | 300-500 | 200-400 |
 | Link preview | 250-400 | 100-200 |
+
+> For CJK (Chinese/Japanese/Korean) text, increase suggested widths by approximately 1.5x — CJK characters are roughly twice as wide as Latin characters and need more horizontal space to avoid awkward line breaks.
 
 ## Validation Checklist
 


### PR DESCRIPTION
## Summary

Two related documentation gaps in the JSON Canvas skill, both reported in #57.

### 1. CJK sizing guidance

The layout table suggests fixed pixel widths for node types, but CJK characters (Chinese, Japanese, Korean) are roughly twice as wide as Latin characters. Nodes sized for Latin text become cramped with CJK content, causing awkward line breaks.

Adds a callout after the table: multiply suggested widths by ~1.5x for CJK content.

### 2. File path pitfall for names containing double quotes

If a vault file name contains `"` (e.g. `分类网络到 CIDR 的演化本质是"隐式编码→显式标注".md`), hand-writing the canvas JSON produces a broken string literal. The fix is to build the JSON via `json.dump`, which escapes special characters automatically.

Adds a **File path pitfall** note (matching the existing **Newline pitfall** style in Text Nodes) with a minimal `python3 -c` example.

Fixes #57

## Changes

- `skills/json-canvas/SKILL.md`: add CJK width callout after layout table; add file path pitfall note after File Nodes example