### PR TITLE
docs(obsidian-cli): discover and confirm vault when multiple vaults exist

### DIFF
--- a/skills/obsidian-cli/SKILL.md
+++ b/skills/obsidian-cli/SKILL.md
@@ -42,6 +42,14 @@ Commands target the most recently focused vault by default. Use `vault=<name>` a
 obsidian vault="My Vault" search query="test"
 ```
 
+If the user has not specified a vault and the task spans multiple commands, first check how many vaults are available:
+
+```bash
+obsidian vaults
+```
+
+If more than one vault is listed, ask the user which vault to use before proceeding. If only one vault exists, use it directly without asking.
+
 ## Common patterns
 
 ```bash


### PR DESCRIPTION
## Summary

When a user has multiple Obsidian vaults, the skill silently targets the most recently focused vault. This can cause operations to land in the wrong vault without any warning.

This adds a behavioral instruction to the **Vault targeting** section: if the target vault is unspecified and the task spans multiple commands, first run `obsidian vaults` to check how many vaults exist. If more than one is listed, ask the user which vault to use. If there is only one vault, use it directly.

The `vaults` command to list known vaults already exists in the CLI (see https://help.obsidian.md/cli), so this is a documentation-only change.

Fixes #49

## Changes

- `skills/obsidian-cli/SKILL.md`: expand Vault targeting section with multi-vault discovery guidance