### PR TITLE
Fix tag format rule: numbers are allowed as the first character

### DIFF
--- a/skills/obsidian-markdown/SKILL.md
+++ b/skills/obsidian-markdown/SKILL.md
@@ -100,7 +100,7 @@ See [PROPERTIES.md](references/PROPERTIES.md) for all property types, tag syntax
 #nested/tag             Nested tag with hierarchy
 ```
 
-Tags can contain letters, numbers (not first character), underscores, hyphens, and forward slashes. Tags can also be defined in frontmatter under the `tags` property.
+Tags can contain letters, numbers, underscores, hyphens, and forward slashes, but must include at least one non-numerical character (`#1984` is invalid, `#1984book` is valid). Tags can also be defined in frontmatter under the `tags` property.
 
 ## Comments
 


### PR DESCRIPTION
## What

The `obsidian-markdown` skill states that tag numbers cannot be the first character:

> Tags can contain letters, numbers (not first character), underscores, hyphens, and forward slashes.

This is inaccurate. Obsidian's only numeric restriction is that a tag **must contain at least one non-numerical character** — a tag *can* start with a number.

## Evidence

Per the [official Obsidian tags documentation](https://help.obsidian.md/tags):

> Tags must contain at least one non-numerical character.

Examples: `#1984` is invalid (all numbers), but `#1984book` is valid — and it starts with a digit.

## Change

Updated the rule to describe the actual constraint, with valid/invalid examples.

🤖 Generated with [Claude Code](https://claude.com/claude-code)